### PR TITLE
Fix Permission Issues on OpenShift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
-language: ruby
-rvm:
-  - 2.5
 jobs:
   include:
     - stage: test
+      language: ruby
+      rvm: 2.5
       script: rake test
     - stage: build docker image
+      language: minimal
       services:
         - docker
       script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@ COPY src/ src/
 RUN addgroup --system ssh && \
     adduser --system ssh
 
-RUN chgrp -R 0 /sectools/ && \
-    chmod -R g=u /sectools/ && \
-    chown -R ssh /sectools/
+RUN chgrp -R 0 /ssh_scan/ && \
+    chmod -R g=u /ssh_scan/ && \
+    chown -R ssh /ssh_scan/
 
 USER ssh
 

--- a/src/ssh_scan.rb
+++ b/src/ssh_scan.rb
@@ -31,7 +31,7 @@ class SshScan
 		begin
       resultsFile = File.open("/tmp/raw-results.txt", "w+")
 
-			sshCommandLine = "ssh_scan -f #{Pathname.new(@targetfile)} -o #{Pathname.new(resultsFile)}"
+			sshCommandLine = "ssh_scan --fingerprint-db /tmp/fingerprint-db.yml -f #{Pathname.new(@targetfile)} -o #{Pathname.new(resultsFile)}"
 
 			if not @config.ssh_policy_file.nil?
 				sshCommandLine += "-P #{@config.filePath} "


### PR DESCRIPTION
Scans on performed by scanners running inside a OpenShift cluster were failing because of permission issues.

The root cause of this problem was the `.ssh_scan_fingerprints.yml` which the ssh scanner tried, but was not permitted to write to the home directory. This file is now configured to be stored in the `/tmp` directory were the user definitely is allowed to write.