### PR TITLE
Fix Nil Class Exception if no Policy File is Provided

### DIFF
--- a/src/ssh_configuration.rb
+++ b/src/ssh_configuration.rb
@@ -17,8 +17,8 @@ class SshConfiguration
 
     config.policies_directory = policies_directory
     config.job_id = job_id
-    config.ssh_policy_file = target.dig('attributes','SSH_POLICY_FILE')
-    config.ssh_timeout_seconds = target.dig('attributes','SSH_TIMEOUT_SECONDS')
+    config.ssh_policy_file = target.dig('attributes','SSH_POLICY_FILE') unless !target.dig('attributes','SSH_POLICY_FILE')
+    config.ssh_timeout_seconds = target.dig('attributes','SSH_TIMEOUT_SECONDS') unless !target.dig('attributes','SSH_TIMEOUT_SECONDS')
     config
   end
 


### PR DESCRIPTION
ssh_configuration.rb is throwing nilclass exception by digging for policy file if not provided. This will add nilclass controlflow.