### PR TITLE
Prevent crashes due to ENOPROTOOPT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:alpine
+FROM ruby:2.6.3-alpine3.10
 
 WORKDIR /sectools
 ADD Gemfile /sectools

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ ADD Gemfile /sectools
 ADD Gemfile.lock /sectools
 
 # required for ssh-keyscan
-RUN apk --update add openssh-client && apk --update add bash
+RUN apk --update add openssh-client bash ca-certificates && \
+    update-ca-certificates && \
+    rm -rf /var/cache/apk/*
 
 RUN gem install ssh_scan bundler
 
@@ -16,7 +18,6 @@ RUN apk --update add --virtual build-dependencies ruby-dev build-base && \
     rm -rf /var/cache/apk/*
 
 COPY . /ssh_scan
-
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 CMD curl --fail http://localhost:8080/status || exit 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM ruby:2.6.3-alpine3.10
+FROM ruby:alpine
 
 WORKDIR /sectools
 ADD Gemfile /sectools
 ADD Gemfile.lock /sectools
 
 # required for ssh-keyscan
-RUN apk --update add openssh-client bash ca-certificates && \
-    update-ca-certificates && \
+RUN apk --update add openssh-client && apk --update add bash && \
     rm -rf /var/cache/apk/*
 
 RUN gem install ssh_scan bundler

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gem "sinatra"
 gem "rest-client"
-gem "ssh_scan", "0.0.41"
+gem "ssh_scan", :git => "https://github.com/secureCodeBox/ssh_scan.git"
 
-gem "ruby-scanner-scaffolding", :git => "git://github.com/secureCodeBox/ruby-scanner-scaffolding.git", :tag => "v1.0.0"
+gem "ruby-scanner-scaffolding", :git => "https://github.com/secureCodeBox/ruby-scanner-scaffolding.git", :tag => "v1.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gem "sinatra"
 gem "rest-client"
-gem "ssh_scan"
+gem "ssh_scan", "0.0.41"
 
-gem "ruby-scanner-scaffolding", :git => "https://github.com/secureCodeBox/ruby-scanner-scaffolding.git", :tag => "v1.0.0"
+gem "ruby-scanner-scaffolding", :git => "git://github.com/secureCodeBox/ruby-scanner-scaffolding.git", :tag => "v1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/secureCodeBox/ruby-scanner-scaffolding.git
+  remote: git://github.com/secureCodeBox/ruby-scanner-scaffolding.git
   revision: fff6c92edffb1f55bde432156ffd60c38c034e49
   tag: v1.0.0
   specs:
@@ -38,7 +38,7 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.5)
       tilt (~> 2.0)
-    ssh_scan (0.0.40)
+    ssh_scan (0.0.41)
       bindata (= 2.4.3)
       net-ssh (= 5.0.2)
       netaddr (= 1.5.1)
@@ -58,7 +58,7 @@ DEPENDENCIES
   rest-client
   ruby-scanner-scaffolding!
   sinatra
-  ssh_scan
+  ssh_scan (= 0.0.41)
 
 BUNDLED WITH
    2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,19 @@
 GIT
-  remote: git://github.com/secureCodeBox/ruby-scanner-scaffolding.git
+  remote: https://github.com/secureCodeBox/ruby-scanner-scaffolding.git
   revision: fff6c92edffb1f55bde432156ffd60c38c034e49
   tag: v1.0.0
   specs:
     ruby-scanner-scaffolding (1.0.0)
+
+GIT
+  remote: https://github.com/secureCodeBox/ssh_scan.git
+  revision: 414332a84546afaf89485a1268e3824c70914616
+  specs:
+    ssh_scan (0.0.41)
+      bindata (= 2.4.3)
+      net-ssh (= 5.0.2)
+      netaddr (= 1.5.1)
+      sshkey
 
 GEM
   remote: https://rubygems.org/
@@ -38,11 +48,6 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.5)
       tilt (~> 2.0)
-    ssh_scan (0.0.41)
-      bindata (= 2.4.3)
-      net-ssh (= 5.0.2)
-      netaddr (= 1.5.1)
-      sshkey
     sshkey (2.0.0)
     tilt (2.0.9)
     unf (0.1.4)
@@ -58,7 +63,7 @@ DEPENDENCIES
   rest-client
   ruby-scanner-scaffolding!
   sinatra
-  ssh_scan (= 0.0.41)
+  ssh_scan!
 
 BUNDLED WITH
    2.0.1

--- a/src/main.rb
+++ b/src/main.rb
@@ -16,13 +16,13 @@ client = SshWorker.new(
 	['PROCESS_TARGETS']
 )
 
-	healthcheckClient = Healthcheck.new
+healthcheckClient = Healthcheck.new
 
 get '/status' do
 	status 500
 	if client.healthy?
 		status 200
-  end
+	end
 	content_type :json
 	healthcheckClient.check(client)
 end

--- a/src/ssh_scan.rb
+++ b/src/ssh_scan.rb
@@ -6,7 +6,7 @@ require 'pathname'
 require_relative './ssh_result_transformer'
 
 $logger = Logger.new(STDOUT)
-
+$logger.level = if ENV.key? 'DEBUG' then Logger::DEBUG else Logger::INFO end
 
 class SshScan
 	attr_reader :raw_results

--- a/src/ssh_worker.rb
+++ b/src/ssh_worker.rb
@@ -29,7 +29,6 @@ class SshWorker < CamundaWorker
 		if scan.errored
 			@errored = true
 		end
-		scan
 
 		{
 				findings: scan.results,


### PR DESCRIPTION
This change changes the ssh_scan version used to a secureCodeBox fork of the ssh_scan tools which has a fix for crashes due to `ENOPROTOOPT` errors.

It also ensures that the log level actually respects the `DEBUG` Env var, as it was initially intended.