### PR TITLE
Expand SSH Finding Model into multiple Categories

### DIFF
--- a/src/main.rb
+++ b/src/main.rb
@@ -4,26 +4,24 @@ require 'bundler'
 Bundler.setup(:default)
 require 'ruby-scanner-scaffolding'
 require 'ruby-scanner-scaffolding/healthcheck'
-require_relative "./ssh_worker"
+require_relative './ssh_worker'
 
-set :port, 8080
+set :port, 8_080
 set :bind, '0.0.0.0'
 set :environment, :production
 
-client = SshWorker.new(
-	'http://localhost:8080',
-	'ssh_webserverscan',
-	['PROCESS_TARGETS']
-)
+client =
+  SshWorker.new(
+    'http://localhost:8080',
+    'ssh_webserverscan',
+    %w[PROCESS_TARGETS]
+  )
 
 healthcheckClient = Healthcheck.new
 
 get '/status' do
-	status 500
-	if client.healthy?
-		status 200
-	end
-	content_type :json
-	healthcheckClient.check(client)
+  status 500
+  status 200 if client.healthy?
+  content_type :json
+  healthcheckClient.check(client)
 end
-

--- a/src/ssh_configuration.rb
+++ b/src/ssh_configuration.rb
@@ -1,8 +1,9 @@
 def is_set(val)
   if val != ''
+
   elsif val.is_a?(Array)
-  val.length != 0
-end
+    val.length != 0
+  end
 end
 
 class SshConfiguration
@@ -11,14 +12,20 @@ class SshConfiguration
   attr_accessor :ssh_policy_file
   attr_accessor :ssh_timeout_seconds
 
-
-  def self.from_target(job_id, target, policies_directory = "/securecodebox/static/")
+  def self.from_target(
+    job_id, target, policies_directory = '/securecodebox/static/'
+  )
     config = SshConfiguration.new
 
     config.policies_directory = policies_directory
     config.job_id = job_id
-    config.ssh_policy_file = target.dig('attributes','SSH_POLICY_FILE') unless !target.dig('attributes','SSH_POLICY_FILE')
-    config.ssh_timeout_seconds = target.dig('attributes','SSH_TIMEOUT_SECONDS') unless !target.dig('attributes','SSH_TIMEOUT_SECONDS')
+    unless !target.dig('attributes', 'SSH_POLICY_FILE')
+      config.ssh_policy_file = target.dig('attributes', 'SSH_POLICY_FILE')
+    end
+    unless !target.dig('attributes', 'SSH_TIMEOUT_SECONDS')
+      config.ssh_timeout_seconds =
+        target.dig('attributes', 'SSH_TIMEOUT_SECONDS')
+    end
     config
   end
 

--- a/src/ssh_result_transformer.rb
+++ b/src/ssh_result_transformer.rb
@@ -9,6 +9,7 @@ class SshResultTransformer
 
   def transform(results, timed_out: false)
     findings = []
+
     results.each do |r|
       findings << {
           id: @uuid_provider.uuid,
@@ -32,7 +33,8 @@ class SshResultTransformer
               start_time: r.dig('start_time'),
               end_time: r.dig('end_time'),
               scan_duration_seconds: r.dig('scan_duration_seconds'),
-              references: r.dig('compliance', 'references')
+              references: r.dig('compliance', 'references'),
+              auth_methods: r.dig('auth_methods').reduce({}) { |h, v| h[v] = true; h }
           }
       }
 

--- a/src/ssh_result_transformer.rb
+++ b/src/ssh_result_transformer.rb
@@ -53,10 +53,10 @@ class SshResultTransformer
           .each do |policy_violation_message|
           findings <<
             create_policy_violation_finding(
-              message: policy_violation_message,
-              location: location,
-              hostname: hostname,
-              ip_address: r.dig('ip')
+              policy_violation_message,
+              location,
+              hostname,
+              r.dig('ip')
             )
         end
       end
@@ -131,7 +131,7 @@ class SshResultTransformer
   end
 
   def create_policy_violation_finding(
-    message:, location:, hostname:, ip_address:
+    message, location, hostname, ip_address
   )
     policy_violation_type = get_policy_violation_type(message)
 

--- a/src/ssh_result_transformer.rb
+++ b/src/ssh_result_transformer.rb
@@ -118,6 +118,11 @@ class SshResultTransformer
         name: 'Discouraged SSH authentication methods are used',
         category: 'Discouraged SSH authentication methods'
       }
+    when /^Update your ssh version to/
+      {
+        name: 'Outdated SSH protocol version used',
+        category: 'Outdated SSH Protocol Version'
+      }
     else
       raise Exception.new "Unexpected Policy Violation Type: '#{message}'"
     end

--- a/src/ssh_result_transformer.rb
+++ b/src/ssh_result_transformer.rb
@@ -141,15 +141,4 @@ class SshResultTransformer
       attributes: { hostname: hostname, payload: payload }
     }
   end
-
-  def decideSeverity(grade)
-    case grade
-    when 'A', 'B'
-      'LOW'
-    when 'C', 'D'
-      'MEDIUM'
-    when 'E', 'F'
-      'HIGH'
-    end
-  end
 end

--- a/src/ssh_result_transformer.rb
+++ b/src/ssh_result_transformer.rb
@@ -21,8 +21,8 @@ class SshResultTransformer
           hint: '',
           location: r.dig('ip'),
           attributes: {
-              hostname: r.dig('hostname'),
-              server_banner: r.dig('server_banner'),
+              hostname: (r.dig('hostname') unless r.dig('hostname').empty?),
+              server_banner: (r.dig('server_banner') unless r.dig('server_banner').empty?),
               ssh_version: r.dig('ssh_version'),
               os_cpe: r.dig('os_cpe'),
               ssh_lib_cpe: r.dig('ssh_lib_cpe'),

--- a/src/ssh_result_transformer.rb
+++ b/src/ssh_result_transformer.rb
@@ -10,54 +10,56 @@ class SshResultTransformer
     findings = []
 
     results.each do |r|
-      location = (r.dig('hostname').empty?) ? r.dig('ip') : r.dig('hostname')
-      hostname = (r.dig('hostname') unless r.dig('hostname').empty?)
-      findings <<
-        {
-          id: @uuid_provider.uuid,
-          name: 'SSH Service Information',
-          description: '',
-          category: 'SSH Service',
-          osi_layer: 'NETWORK',
-          severity: 'INFORMATIONAL',
-          reference: {},
-          hint: '',
-          location: location,
-          attributes: {
-            hostname: hostname,
-            ip_address: r.dig('ip'),
-            server_banner:
-              (r.dig('server_banner') unless r.dig('server_banner').empty?),
-            ssh_version: r.dig('ssh_version'),
-            os_cpe: r.dig('os_cpe'),
-            ssh_lib_cpe: r.dig('ssh_lib_cpe'),
-            compliance_policy: r.dig('compliance', 'policy'),
-            compliant: r.dig('compliance', 'compliant'),
-            grade: r.dig('compliance', 'grade'),
-            start_time: r.dig('start_time'),
-            end_time: r.dig('end_time'),
-            scan_duration_seconds: r.dig('scan_duration_seconds'),
-            references: r.dig('compliance', 'references'),
-            auth_methods: r.dig('auth_methods'),
-            key_algorithms: r.dig('key_algorithms'),
-            encryption_algorithms:
-              r.dig('encryption_algorithms_server_to_client'),
-            mac_algorithms: r.dig('mac_algorithms_server_to_client'),
-            compression_algorithms:
-              r.dig('compression_algorithms_server_to_client')
-          }
-        }
+      unless r.has_key? "error"
+        location = (r.dig('hostname').empty?) ? r.dig('ip') : r.dig('hostname')
+        hostname = (r.dig('hostname') unless r.dig('hostname').empty?)
+        findings <<
+            {
+                id: @uuid_provider.uuid,
+                name: 'SSH Service Information',
+                description: '',
+                category: 'SSH Service',
+                osi_layer: 'NETWORK',
+                severity: 'INFORMATIONAL',
+                reference: {},
+                hint: '',
+                location: location,
+                attributes: {
+                    hostname: hostname,
+                    ip_address: r.dig('ip'),
+                    server_banner:
+                        (r.dig('server_banner') unless r.dig('server_banner').empty?),
+                    ssh_version: r.dig('ssh_version'),
+                    os_cpe: r.dig('os_cpe'),
+                    ssh_lib_cpe: r.dig('ssh_lib_cpe'),
+                    compliance_policy: r.dig('compliance', 'policy'),
+                    compliant: r.dig('compliance', 'compliant'),
+                    grade: r.dig('compliance', 'grade'),
+                    start_time: r.dig('start_time'),
+                    end_time: r.dig('end_time'),
+                    scan_duration_seconds: r.dig('scan_duration_seconds'),
+                    references: r.dig('compliance', 'references'),
+                    auth_methods: r.dig('auth_methods'),
+                    key_algorithms: r.dig('key_algorithms'),
+                    encryption_algorithms:
+                        r.dig('encryption_algorithms_server_to_client'),
+                    mac_algorithms: r.dig('mac_algorithms_server_to_client'),
+                    compression_algorithms:
+                        r.dig('compression_algorithms_server_to_client')
+                }
+            }
 
-      unless r.dig('compliance', 'recommendations').nil?
-        r.dig('compliance', 'recommendations')
-          .each do |policy_violation_message|
-          findings <<
-            create_policy_violation_finding(
-              policy_violation_message,
-              location,
-              hostname,
-              r.dig('ip')
-            )
+        unless r.dig('compliance', 'recommendations').nil?
+          r.dig('compliance', 'recommendations')
+              .each do |policy_violation_message|
+            findings <<
+                create_policy_violation_finding(
+                    policy_violation_message,
+                    location,
+                    hostname,
+                    r.dig('ip')
+                )
+          end
         end
       end
     end

--- a/src/ssh_result_transformer.rb
+++ b/src/ssh_result_transformer.rb
@@ -67,6 +67,7 @@ class SshResultTransformer
     findings
   end
 
+  # rubocop:disable MethodComplexity
   def get_policy_violation_type(message)
     type = message.split(': ')[0]
 
@@ -131,6 +132,7 @@ class SshResultTransformer
       raise Exception.new "Unexpected Policy Violation Type: '#{message}'"
     end
   end
+  # rubocop:enable MethodComplexity
 
   def create_policy_violation_finding(
     message, location, hostname, ip_address

--- a/src/ssh_result_transformer.rb
+++ b/src/ssh_result_transformer.rb
@@ -35,11 +35,13 @@ class SshResultTransformer
             end_time: r.dig('end_time'),
             scan_duration_seconds: r.dig('scan_duration_seconds'),
             references: r.dig('compliance', 'references'),
-            auth_methods:
-              r.dig('auth_methods').reduce({}) do |h, v|
-                h[v] = true
-                h
-              end
+            auth_methods: r.dig('auth_methods'),
+            key_algorithms: r.dig('key_algorithms'),
+            encryption_algorithms:
+              r.dig('encryption_algorithms_server_to_client'),
+            mac_algorithms: r.dig('mac_algorithms_server_to_client'),
+            compression_algorithms:
+              r.dig('compression_algorithms_server_to_client')
           }
         }
 

--- a/src/ssh_result_transformer.rb
+++ b/src/ssh_result_transformer.rb
@@ -3,15 +3,15 @@ require 'json'
 
 class SshResultTransformer
   def initialize(uuid_provider = SecureRandom)
-    @uuid_provider = uuid_provider;
+    @uuid_provider = uuid_provider
   end
-
 
   def transform(results, timed_out: false)
     findings = []
 
     results.each do |r|
-      findings << {
+      findings <<
+        {
           id: @uuid_provider.uuid,
           name: 'SSH Compliance',
           description: 'SSH Compliance Information',
@@ -22,25 +22,31 @@ class SshResultTransformer
           hint: '',
           location: r.dig('ip'),
           attributes: {
-              hostname: (r.dig('hostname') unless r.dig('hostname').empty?),
-              server_banner: (r.dig('server_banner') unless r.dig('server_banner').empty?),
-              ssh_version: r.dig('ssh_version'),
-              os_cpe: r.dig('os_cpe'),
-              ssh_lib_cpe: r.dig('ssh_lib_cpe'),
-              compliance_policy: r.dig('compliance', 'policy'),
-              compliant: r.dig('compliance', 'compliant'),
-              grade: r.dig('compliance', 'grade'),
-              start_time: r.dig('start_time'),
-              end_time: r.dig('end_time'),
-              scan_duration_seconds: r.dig('scan_duration_seconds'),
-              references: r.dig('compliance', 'references'),
-              auth_methods: r.dig('auth_methods').reduce({}) { |h, v| h[v] = true; h }
+            hostname: (r.dig('hostname') unless r.dig('hostname').empty?),
+            server_banner:
+              (r.dig('server_banner') unless r.dig('server_banner').empty?),
+            ssh_version: r.dig('ssh_version'),
+            os_cpe: r.dig('os_cpe'),
+            ssh_lib_cpe: r.dig('ssh_lib_cpe'),
+            compliance_policy: r.dig('compliance', 'policy'),
+            compliant: r.dig('compliance', 'compliant'),
+            grade: r.dig('compliance', 'grade'),
+            start_time: r.dig('start_time'),
+            end_time: r.dig('end_time'),
+            scan_duration_seconds: r.dig('scan_duration_seconds'),
+            references: r.dig('compliance', 'references'),
+            auth_methods:
+              r.dig('auth_methods').reduce({}) do |h, v|
+                h[v] = true
+                h
+              end
           }
-      }
+        }
 
       unless r.dig('compliance', 'recommendations').nil?
         r.dig('compliance', 'recommendations').each do |f|
-          findings << {
+          findings <<
+            {
               id: @uuid_provider.uuid,
               name: f.split(':')[0],
               description: f.split(':')[1],
@@ -51,7 +57,7 @@ class SshResultTransformer
               hint: '',
               location: r.dig('ip'),
               attributes: {}
-          }
+            }
         end
       end
     end

--- a/src/ssh_scan.rb
+++ b/src/ssh_scan.rb
@@ -6,7 +6,7 @@ require 'pathname'
 require_relative './ssh_result_transformer'
 
 $logger = Logger.new(STDOUT)
-$logger.level = ENV.key? 'DEBUG' ? Logger::DEBUG : Logger::INFO
+$logger.level = if ENV.key? 'DEBUG' then Logger::DEBUG else Logger::INFO end
 
 class SshScan
   attr_reader :raw_results

--- a/src/ssh_scan.rb
+++ b/src/ssh_scan.rb
@@ -6,53 +6,59 @@ require 'pathname'
 require_relative './ssh_result_transformer'
 
 $logger = Logger.new(STDOUT)
-$logger.level = if ENV.key? 'DEBUG' then Logger::DEBUG else Logger::INFO end
+$logger.level = ENV.key? 'DEBUG' ? Logger::DEBUG : Logger::INFO
 
 class SshScan
-	attr_reader :raw_results
-	attr_reader :results
-	attr_reader :errored
+  attr_reader :raw_results
+  attr_reader :results
+  attr_reader :errored
 
-	def initialize(targetfile, config)
-		@targetfile = targetfile
-		@config = config
-		@errored = false
-		@transformer = SshResultTransformer.new
-	end
+  def initialize(targetfile, config)
+    @targetfile = targetfile
+    @config = config
+    @errored = false
+    @transformer = SshResultTransformer.new
+  end
 
-	def start
-		$logger.info "Running scan for #{File.basename(@targetfile, File.extname(@targetfile))}"
-			start_scan
-			$logger.info "Retrieving scan results for #{File.basename(@targetfile, File.extname(@targetfile))}"
-			get_scan_report
-	end
+  def start
+    $logger.info "Running scan for #{
+                   File.basename(@targetfile, File.extname(@targetfile))
+                 }"
+    start_scan
+    $logger.info "Retrieving scan results for #{
+                   File.basename(@targetfile, File.extname(@targetfile))
+                 }"
+    get_scan_report
+  end
 
-	def start_scan
-		begin
-      resultsFile = File.open("/tmp/raw-results.txt", "w+")
+  def start_scan
+    resultsFile = File.open('/tmp/raw-results.txt', 'w+')
 
-			sshCommandLine = "ssh_scan --fingerprint-db /tmp/fingerprint-db.yml -f #{Pathname.new(@targetfile)} -o #{Pathname.new(resultsFile)}"
+    sshCommandLine =
+      "ssh_scan --fingerprint-db /tmp/fingerprint-db.yml -f #{
+        Pathname.new(@targetfile)
+      } -o #{Pathname.new(resultsFile)}"
 
-			if not @config.ssh_policy_file.nil?
-				sshCommandLine += "-P #{@config.filePath} "
-			end
-			if not @config.ssh_timeout_seconds.nil?
-				sshCommandLine += "-T #{@config.ssh_timeout_seconds}"
-      end
-      resultsFile.write(`#{sshCommandLine}`)
-      @raw_results = JSON.parse(resultsFile.read)
-      File.delete(resultsFile)
-    rescue => err
-			$logger.warn err
-			raise CamundaIncident.new("Failed to start SSH scan.", "This is most likely related to a error in the configuration. Check the SSH logs for more details.")
-		end
-	end
+    if not @config.ssh_policy_file.nil?
+      sshCommandLine += "-P #{@config.filePath} "
+    end
+    if not @config.ssh_timeout_seconds.nil?
+      sshCommandLine += "-T #{@config.ssh_timeout_seconds}"
+    end
+    resultsFile.write(`#{sshCommandLine}`)
+    @raw_results = JSON.parse(resultsFile.read)
+    File.delete(resultsFile)
+  rescue => err
+    $logger.warn err
+    raise CamundaIncident.new(
+            'Failed to start SSH scan.',
+            'This is most likely related to a error in the configuration. Check the SSH logs for more details.'
+          )
+  end
 
-	def get_scan_report
-		begin
-			@results = @transformer.transform(@raw_results)
-		rescue => err
-			$logger.warn err
-		end
-	end
+  def get_scan_report
+    @results = @transformer.transform(@raw_results)
+  rescue => err
+    $logger.warn err
+  end
 end

--- a/src/ssh_worker.rb
+++ b/src/ssh_worker.rb
@@ -1,40 +1,48 @@
 require 'json'
 require 'ruby-scanner-scaffolding'
 
-require_relative "./ssh_configuration"
+require_relative './ssh_configuration'
 
-require_relative "./ssh_scan"
+require_relative './ssh_scan'
 
 class SshWorker < CamundaWorker
-	attr_accessor :errored
+  attr_accessor :errored
 
-	def initialize(camunda_url, topic, variables, task_lock_duration = 3600000, poll_interval = 5)
-		super(camunda_url, topic, variables, task_lock_duration = 3600000, poll_interval = 5)
+  def initialize(
+    camunda_url,
+    topic,
+    variables,
+    task_lock_duration = 3_600_000,
+    poll_interval = 5
+  )
+    super(
+      camunda_url,
+      topic,
+      variables,
+      task_lock_duration = 3_600_000,
+      poll_interval = 5
+    )
 
-		@errored = false
-	end
+    @errored = false
+  end
 
-	def work(job_id, targets)
-		locations = targets.map {|target|
-			target.dig('location')
-		}
-		config = SshConfiguration.from_target(job_id, targets.first)
+  def work(job_id, targets)
+    locations = targets.map { |target| target.dig('location') }
+    config = SshConfiguration.from_target(job_id, targets.first)
 
-		targetFile = File.open("/tmp/targets-of-#{job_id}.txt", "w+")
-		targetFile.puts locations
-		targetFile.close
+    targetFile = File.open("/tmp/targets-of-#{job_id}.txt", 'w+')
+    targetFile.puts locations
+    targetFile.close
 
-		scan = SshScan.new(targetFile, config)
-		scan.start
-		if scan.errored
-			@errored = true
-		end
+    scan = SshScan.new(targetFile, config)
+    scan.start
+    @errored = true if scan.errored
 
-		{
-				findings: scan.results,
-				rawFindings: scan.raw_results.to_json,
-				scannerId: @worker_id.to_s,
-				scannerType: 'ssh'
-		}
-	end
+    {
+      findings: scan.results,
+      rawFindings: scan.raw_results.to_json,
+      scannerId: @worker_id.to_s,
+      scannerType: 'ssh'
+    }
+  end
 end

--- a/tests/ssh_result_transformer_test.rb
+++ b/tests/ssh_result_transformer_test.rb
@@ -9,7 +9,6 @@ class FakeUuidProvider
 end
 
 class SshResultTransformerTest < Test::Unit::TestCase
-
   def setup
     @transformer = SshResultTransformer.new(FakeUuidProvider.new)
   end
@@ -73,33 +72,35 @@ EOM
     result = JSON.parse(test_raw)
 
     assert_equal(
-        @transformer.transform(result),
-        [{
-             id: '49bf7fd3-8512-4d73-a28f-608e493cd726',
-             name: 'SSH Compliance',
-             description: 'SSH Compliance Information',
-             category: 'SSH Service',
-             osi_layer: 'NETWORK',
-             severity: 'INFORMATIONAL',
-             reference: {},
-             hint: '',
-             location: '127.0.0.1',
-             attributes: {
-                 compliance_policy: nil,
-                 compliant: nil,
-                 hostname: nil,
-                 os_cpe: 'o:unknown',
-                 grade: nil,
-                 start_time: '2019-03-20 14:54:36 +0100',
-                 end_time: '2019-03-20 14:54:41 +0100',
-                 scan_duration_seconds: 5.138688,
-                 server_banner: nil,
-                 ssh_lib_cpe: 'a:unknown',
-                 ssh_version: 'unknown',
-                 references: nil,
-                 auth_methods: {}
-             }
-         }]
+      @transformer.transform(result),
+      [
+        {
+          id: '49bf7fd3-8512-4d73-a28f-608e493cd726',
+          name: 'SSH Compliance',
+          description: 'SSH Compliance Information',
+          category: 'SSH Service',
+          osi_layer: 'NETWORK',
+          severity: 'INFORMATIONAL',
+          reference: {},
+          hint: '',
+          location: '127.0.0.1',
+          attributes: {
+            compliance_policy: nil,
+            compliant: nil,
+            hostname: nil,
+            os_cpe: 'o:unknown',
+            grade: nil,
+            start_time: '2019-03-20 14:54:36 +0100',
+            end_time: '2019-03-20 14:54:41 +0100',
+            scan_duration_seconds: 5.138688,
+            server_banner: nil,
+            ssh_lib_cpe: 'a:unknown',
+            ssh_version: 'unknown',
+            references: nil,
+            auth_methods: {}
+          }
+        }
+      ]
     )
   end
 
@@ -240,70 +241,66 @@ EOM
     findings = @transformer.transform(result)
 
     assert_equal(
-        findings.first,
-        {
-            :attributes => {
-                :compliance_policy => "Mozilla Modern",
-                :compliant => false,
-                :end_time => "2019-09-23 17:47:51 +0200",
-                :grade => "C",
-                :hostname => "securecodebox.io",
-                :os_cpe => "o:canonical:ubuntu:16.04",
-                :references => ["https://wiki.mozilla.org/Security/Guidelines/OpenSSH"],
-                :scan_duration_seconds => 0.699356,
-                :server_banner => "SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.4",
-                :ssh_lib_cpe => "a:openssh:openssh:7.2p2",
-                :ssh_version => 2.0,
-                :start_time => "2019-09-23 17:47:50 +0200",
-                :auth_methods => {
-                    "publickey" => true
-                }
-            },
-            :category => "SSH Service",
-            :description => "SSH Compliance Information",
-            :hint => "",
-            :id => "49bf7fd3-8512-4d73-a28f-608e493cd726",
-            :location => "138.201.126.99",
-            :name => "SSH Compliance",
-            :osi_layer => "NETWORK",
-            :reference => {},
-            :severity => "INFORMATIONAL"
-        }
+      findings.first,
+      {
+        attributes: {
+          compliance_policy: 'Mozilla Modern',
+          compliant: false,
+          end_time: '2019-09-23 17:47:51 +0200',
+          grade: 'C',
+          hostname: 'securecodebox.io',
+          os_cpe: 'o:canonical:ubuntu:16.04',
+          references: %w[https://wiki.mozilla.org/Security/Guidelines/OpenSSH],
+          scan_duration_seconds: 0.699356,
+          server_banner: 'SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.4',
+          ssh_lib_cpe: 'a:openssh:openssh:7.2p2',
+          ssh_version: 2.0,
+          start_time: '2019-09-23 17:47:50 +0200',
+          auth_methods: { 'publickey' => true }
+        },
+        category: 'SSH Service',
+        description: 'SSH Compliance Information',
+        hint: '',
+        id: '49bf7fd3-8512-4d73-a28f-608e493cd726',
+        location: '138.201.126.99',
+        name: 'SSH Compliance',
+        osi_layer: 'NETWORK',
+        reference: {},
+        severity: 'INFORMATIONAL'
+      }
     )
 
     assert_equal(
       findings[1],
       {
-          :attributes => {},
-          :category => "SSH Service",
-          :description => " diffie-hellman-group14-sha1",
-          :hint => "",
-          :id => "49bf7fd3-8512-4d73-a28f-608e493cd726",
-          :location => "138.201.126.99",
-          :name => "Remove these key exchange algorithms",
-          :osi_layer => "NETWORK",
-          :reference => {},
-          :severity => "MEDIUM"
+        attributes: {},
+        category: 'SSH Service',
+        description: ' diffie-hellman-group14-sha1',
+        hint: '',
+        id: '49bf7fd3-8512-4d73-a28f-608e493cd726',
+        location: '138.201.126.99',
+        name: 'Remove these key exchange algorithms',
+        osi_layer: 'NETWORK',
+        reference: {},
+        severity: 'MEDIUM'
       }
     )
 
     assert_equal(
       findings[2],
-        {
-            :attributes => {},
-            :category => "SSH Service",
-            :description =>
-                " umac-64-etm@openssh.com, hmac-sha1-etm@openssh.com, umac-64@openssh.com, hmac-sha1",
-            :hint => "",
-            :id => "49bf7fd3-8512-4d73-a28f-608e493cd726",
-            :location => "138.201.126.99",
-            :name => "Remove these MAC algorithms",
-            :osi_layer => "NETWORK",
-            :reference => {},
-            :severity => "MEDIUM"
-        }
+      {
+        attributes: {},
+        category: 'SSH Service',
+        description:
+          ' umac-64-etm@openssh.com, hmac-sha1-etm@openssh.com, umac-64@openssh.com, hmac-sha1',
+        hint: '',
+        id: '49bf7fd3-8512-4d73-a28f-608e493cd726',
+        location: '138.201.126.99',
+        name: 'Remove these MAC algorithms',
+        osi_layer: 'NETWORK',
+        reference: {},
+        severity: 'MEDIUM'
+      }
     )
-
-
   end
 end

--- a/tests/ssh_result_transformer_test.rb
+++ b/tests/ssh_result_transformer_test.rb
@@ -12,13 +12,15 @@ class SshResultTransformerTest < Test::Unit::TestCase
 
   def setup
     @transformer = SshResultTransformer.new(FakeUuidProvider.new)
+  end
 
-    @test_result = <<EOM
+  def test_should_transform_a_empty_result_into_the_finding_format
+    test_raw = <<EOM
 [
   {
-    "ssh_scan_version": "0.0.40",
+    "ssh_scan_version": "0.0.42",
     "ip": "127.0.0.1",
-    "hostname": "localhost",
+    "hostname": "",
     "port": 22,
     "server_banner": "",
     "ssh_version": "unknown",
@@ -67,41 +69,227 @@ class SshResultTransformerTest < Test::Unit::TestCase
     "scan_duration_seconds": 5.138688
   }
 ]
-
 EOM
-  end
-
-  def test_should_transform_a_empty_result_into_the_finding_format
-
-    result = JSON.parse(@test_result)
+    result = JSON.parse(test_raw)
 
     assert_equal(
         @transformer.transform(result),
         [{
-            id: '49bf7fd3-8512-4d73-a28f-608e493cd726',
-            name: 'SSH Compliance',
-            description: 'SSH Compliance Information',
-            category: 'SSH Service',
-            osi_layer: 'NETWORK',
-            severity: 'INFORMATIONAL',
-            reference: {},
-            hint: '',
-            location: '127.0.0.1',
-            attributes: {
-                compliance_policy: nil,
-                compliant: nil,
-                hostname: 'localhost',
-                os_cpe: 'o:unknown',
-                grade: nil,
-                start_time: '2019-03-20 14:54:36 +0100',
-                end_time: '2019-03-20 14:54:41 +0100',
-                scan_duration_seconds: 5.138688,
-                server_banner: '',
-                ssh_lib_cpe: 'a:unknown',
-                ssh_version: 'unknown',
-                references: nil
+             id: '49bf7fd3-8512-4d73-a28f-608e493cd726',
+             name: 'SSH Compliance',
+             description: 'SSH Compliance Information',
+             category: 'SSH Service',
+             osi_layer: 'NETWORK',
+             severity: 'INFORMATIONAL',
+             reference: {},
+             hint: '',
+             location: '127.0.0.1',
+             attributes: {
+                 compliance_policy: nil,
+                 compliant: nil,
+                 hostname: nil,
+                 os_cpe: 'o:unknown',
+                 grade: nil,
+                 start_time: '2019-03-20 14:54:36 +0100',
+                 end_time: '2019-03-20 14:54:41 +0100',
+                 scan_duration_seconds: 5.138688,
+                 server_banner: nil,
+                 ssh_lib_cpe: 'a:unknown',
+                 ssh_version: 'unknown',
+                 references: nil
+             }
+         }]
+    )
+  end
+
+  def test_should_transform_proper_result_into_the_finding_format
+    test_raw = <<EOM
+[
+  {
+    "ssh_scan_version": "0.0.42",
+    "ip": "138.201.126.99",
+    "hostname": "securecodebox.io",
+    "port": 22,
+    "server_banner": "SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.4",
+    "ssh_version": 2.0,
+    "os": "ubuntu",
+    "os_cpe": "o:canonical:ubuntu:16.04",
+    "ssh_lib": "openssh",
+    "ssh_lib_cpe": "a:openssh:openssh:7.2p2",
+    "key_algorithms": [
+      "curve25519-sha256@libssh.org",
+      "ecdh-sha2-nistp256",
+      "ecdh-sha2-nistp384",
+      "ecdh-sha2-nistp521",
+      "diffie-hellman-group-exchange-sha256",
+      "diffie-hellman-group14-sha1"
+    ],
+    "encryption_algorithms_client_to_server": [
+      "chacha20-poly1305@openssh.com",
+      "aes128-ctr",
+      "aes192-ctr",
+      "aes256-ctr",
+      "aes128-gcm@openssh.com",
+      "aes256-gcm@openssh.com"
+    ],
+    "encryption_algorithms_server_to_client": [
+      "chacha20-poly1305@openssh.com",
+      "aes128-ctr",
+      "aes192-ctr",
+      "aes256-ctr",
+      "aes128-gcm@openssh.com",
+      "aes256-gcm@openssh.com"
+    ],
+    "mac_algorithms_client_to_server": [
+      "umac-64-etm@openssh.com",
+      "umac-128-etm@openssh.com",
+      "hmac-sha2-256-etm@openssh.com",
+      "hmac-sha2-512-etm@openssh.com",
+      "hmac-sha1-etm@openssh.com",
+      "umac-64@openssh.com",
+      "umac-128@openssh.com",
+      "hmac-sha2-256",
+      "hmac-sha2-512",
+      "hmac-sha1"
+    ],
+    "mac_algorithms_server_to_client": [
+      "umac-64-etm@openssh.com",
+      "umac-128-etm@openssh.com",
+      "hmac-sha2-256-etm@openssh.com",
+      "hmac-sha2-512-etm@openssh.com",
+      "hmac-sha1-etm@openssh.com",
+      "umac-64@openssh.com",
+      "umac-128@openssh.com",
+      "hmac-sha2-256",
+      "hmac-sha2-512",
+      "hmac-sha1"
+    ],
+    "compression_algorithms_client_to_server": [
+      "none",
+      "zlib@openssh.com"
+    ],
+    "compression_algorithms_server_to_client": [
+      "none",
+      "zlib@openssh.com"
+    ],
+    "languages_client_to_server": [
+
+    ],
+    "languages_server_to_client": [
+
+    ],
+    "auth_methods": [
+      "publickey"
+    ],
+    "keys": {
+      "rsa": {
+        "raw": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDZsud3g6poObLpsD08cjCma1xwHbLsvUs1zjenKftQAt+NXOzgnEV6upmi3YZvQu67dUAWZtX0hS22gMCMIHbql6tbp/isJxLYtLUZLOiTm/vKQz3h/5y9h2oTyeAlA/4Xz4dA8g3RZvFHiQYN2HKvNtafn9hdQrUACZ/KYGbfr839cHeTaLi++lsUAdeeyb7x7WebktH81R3cz7dRhir2qaaqo/84/jR4s3b3koTtvdnFb0mSo2gQJP4QEACcw2w/U3HAhOsxs/Dh4pnJZBKI//HBQrc/ZIRRpfh4QAkX8hxFYGm450phf9Fp5oujjxzESfUw2LA1R2BHL9ZmzC+L",
+        "length": 2048,
+        "fingerprints": {
+          "md5": "5f:cc:75:90:e9:6f:84:38:60:55:6f:9e:4a:a6:a7:b8",
+          "sha1": "0d:4d:2e:0a:c0:c1:77:17:f4:c8:2f:4a:3c:e3:b6:3a:11:00:5e:d1",
+          "sha256": "00:6e:ed:78:9b:be:13:0d:15:0e:84:8b:ba:fc:a1:b1:b0:1e:0b:35:12:15:dd:a6:8d:e6:34:f6:de:47:e5:8d"
+        }
+      },
+      "ecdsa-sha2-nistp256": {
+        "raw": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBZyOh2ar1Ia36mRwV2ZEu87VnzR1hw0nO76hSaO0Rk507wXsyct5RCi3NJ1jNC9yXM7UllKaOX2q/MQGC+NHYw=",
+        "length": 520,
+        "fingerprints": {
+          "md5": "1a:1c:3a:17:e4:a7:5a:85:6d:a5:68:66:07:f4:16:da",
+          "sha1": "1b:0b:e7:c1:57:2b:a4:96:a2:1b:e9:8a:3d:8c:15:e2:87:27:00:bc",
+          "sha256": "71:97:03:d3:2d:c9:e1:04:21:b3:bf:db:e0:f1:c3:6a:0e:50:c8:c9:6d:84:ac:22:25:4c:4b:44:7b:0f:38:e5"
+        }
+      },
+      "ed25519": {
+        "raw": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIACvhiz4GYkEi03nkB6jVXvcDMYFmjn6SoPCyHVK15QK",
+        "length": 248,
+        "fingerprints": {
+          "md5": "ea:9e:55:79:99:40:2c:6b:30:d5:76:48:c8:36:45:32",
+          "sha1": "7b:65:54:74:7e:0f:3f:02:c5:80:8c:49:33:32:41:a9:a6:6a:44:ba",
+          "sha256": "a1:d6:80:82:33:4b:ff:3d:f9:6a:04:57:77:4a:b2:6f:32:d5:6c:d8:13:ba:9c:bf:bf:58:af:60:1b:75:d2:62"
+        }
+      }
+    },
+    "dns_keys": [
+
+    ],
+    "duplicate_host_key_ips": [
+
+    ],
+    "compliance": {
+      "policy": "Mozilla Modern",
+      "compliant": false,
+      "recommendations": [
+        "Remove these key exchange algorithms: diffie-hellman-group14-sha1",
+        "Remove these MAC algorithms: umac-64-etm@openssh.com, hmac-sha1-etm@openssh.com, umac-64@openssh.com, hmac-sha1"
+      ],
+      "references": [
+        "https://wiki.mozilla.org/Security/Guidelines/OpenSSH"
+      ],
+      "grade": "C"
+    },
+    "start_time": "2019-09-23 17:47:50 +0200",
+    "end_time": "2019-09-23 17:47:51 +0200",
+    "scan_duration_seconds": 0.699356
+  }
+]
+EOM
+    result = JSON.parse(test_raw)
+
+    assert_equal(
+        @transformer.transform(result),
+        [
+            {
+                :attributes => {
+                    :compliance_policy => "Mozilla Modern",
+                    :compliant => false,
+                    :end_time => "2019-09-23 17:47:51 +0200",
+                    :grade => "C",
+                    :hostname => "securecodebox.io",
+                    :os_cpe => "o:canonical:ubuntu:16.04",
+                    :references => ["https://wiki.mozilla.org/Security/Guidelines/OpenSSH"],
+                    :scan_duration_seconds => 0.699356,
+                    :server_banner => "SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.4",
+                    :ssh_lib_cpe => "a:openssh:openssh:7.2p2",
+                    :ssh_version => 2.0,
+                    :start_time => "2019-09-23 17:47:50 +0200"
+                },
+                :category => "SSH Service",
+                :description => "SSH Compliance Information",
+                :hint => "",
+                :id => "49bf7fd3-8512-4d73-a28f-608e493cd726",
+                :location => "138.201.126.99",
+                :name => "SSH Compliance",
+                :osi_layer => "NETWORK",
+                :reference => {},
+                :severity => "INFORMATIONAL"
+            },
+            {
+                :attributes => {},
+                :category => "SSH Service",
+                :description => " diffie-hellman-group14-sha1",
+                :hint => "",
+                :id => "49bf7fd3-8512-4d73-a28f-608e493cd726",
+                :location => "138.201.126.99",
+                :name => "Remove these key exchange algorithms",
+                :osi_layer => "NETWORK",
+                :reference => {},
+                :severity => "MEDIUM"
+            },
+            {
+                :attributes => {},
+                :category => "SSH Service",
+                :description =>
+                    " umac-64-etm@openssh.com, hmac-sha1-etm@openssh.com, umac-64@openssh.com, hmac-sha1",
+                :hint => "",
+                :id => "49bf7fd3-8512-4d73-a28f-608e493cd726",
+                :location => "138.201.126.99",
+                :name => "Remove these MAC algorithms",
+                :osi_layer => "NETWORK",
+                :reference => {},
+                :severity => "MEDIUM"
             }
-        }]
+        ]
     )
   end
 end

--- a/tests/ssh_result_transformer_test.rb
+++ b/tests/ssh_result_transformer_test.rb
@@ -97,7 +97,11 @@ EOM
             ssh_lib_cpe: 'a:unknown',
             ssh_version: 'unknown',
             references: nil,
-            auth_methods: {}
+            auth_methods: [],
+            key_algorithms: [],
+            encryption_algorithms: [],
+            mac_algorithms: [],
+            compression_algorithms: []
           }
         }
       ]
@@ -241,7 +245,6 @@ EOM
     findings = @transformer.transform(result)
 
     assert_equal(
-      findings.first,
       {
         attributes: {
           compliance_policy: 'Mozilla Modern',
@@ -256,7 +259,36 @@ EOM
           ssh_lib_cpe: 'a:openssh:openssh:7.2p2',
           ssh_version: 2.0,
           start_time: '2019-09-23 17:47:50 +0200',
-          auth_methods: { 'publickey' => true }
+          auth_methods: %w[publickey],
+          key_algorithms: %w[
+            curve25519-sha256@libssh.org
+            ecdh-sha2-nistp256
+            ecdh-sha2-nistp384
+            ecdh-sha2-nistp521
+            diffie-hellman-group-exchange-sha256
+            diffie-hellman-group14-sha1
+          ],
+          encryption_algorithms: %w[
+            chacha20-poly1305@openssh.com
+            aes128-ctr
+            aes192-ctr
+            aes256-ctr
+            aes128-gcm@openssh.com
+            aes256-gcm@openssh.com
+          ],
+          mac_algorithms: %w[
+            umac-64-etm@openssh.com
+            umac-128-etm@openssh.com
+            hmac-sha2-256-etm@openssh.com
+            hmac-sha2-512-etm@openssh.com
+            hmac-sha1-etm@openssh.com
+            umac-64@openssh.com
+            umac-128@openssh.com
+            hmac-sha2-256
+            hmac-sha2-512
+            hmac-sha1
+          ],
+          compression_algorithms: %w[none zlib@openssh.com]
         },
         category: 'SSH Service',
         description: 'SSH Compliance Information',
@@ -267,11 +299,11 @@ EOM
         osi_layer: 'NETWORK',
         reference: {},
         severity: 'INFORMATIONAL'
-      }
+      },
+      findings.first
     )
 
     assert_equal(
-      findings[1],
       {
         attributes: {},
         category: 'SSH Service',
@@ -283,11 +315,11 @@ EOM
         osi_layer: 'NETWORK',
         reference: {},
         severity: 'MEDIUM'
-      }
+      },
+      findings[1]
     )
 
     assert_equal(
-      findings[2],
       {
         attributes: {},
         category: 'SSH Service',
@@ -300,7 +332,8 @@ EOM
         osi_layer: 'NETWORK',
         reference: {},
         severity: 'MEDIUM'
-      }
+      },
+      findings[2]
     )
   end
 end

--- a/tests/ssh_result_transformer_test.rb
+++ b/tests/ssh_result_transformer_test.rb
@@ -76,8 +76,8 @@ EOM
       [
         {
           id: '49bf7fd3-8512-4d73-a28f-608e493cd726',
-          name: 'SSH Compliance',
-          description: 'SSH Compliance Information',
+          name: 'SSH Service Information',
+          description: '',
           category: 'SSH Service',
           osi_layer: 'NETWORK',
           severity: 'INFORMATIONAL',
@@ -88,6 +88,7 @@ EOM
             compliance_policy: nil,
             compliant: nil,
             hostname: nil,
+            ip_address: '127.0.0.1',
             os_cpe: 'o:unknown',
             grade: nil,
             start_time: '2019-03-20 14:54:36 +0100',
@@ -247,27 +248,10 @@ EOM
     assert_equal(
       {
         attributes: {
+          auth_methods: %w[publickey],
           compliance_policy: 'Mozilla Modern',
           compliant: false,
-          end_time: '2019-09-23 17:47:51 +0200',
-          grade: 'C',
-          hostname: 'securecodebox.io',
-          os_cpe: 'o:canonical:ubuntu:16.04',
-          references: %w[https://wiki.mozilla.org/Security/Guidelines/OpenSSH],
-          scan_duration_seconds: 0.699356,
-          server_banner: 'SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.4',
-          ssh_lib_cpe: 'a:openssh:openssh:7.2p2',
-          ssh_version: 2.0,
-          start_time: '2019-09-23 17:47:50 +0200',
-          auth_methods: %w[publickey],
-          key_algorithms: %w[
-            curve25519-sha256@libssh.org
-            ecdh-sha2-nistp256
-            ecdh-sha2-nistp384
-            ecdh-sha2-nistp521
-            diffie-hellman-group-exchange-sha256
-            diffie-hellman-group14-sha1
-          ],
+          compression_algorithms: %w[none zlib@openssh.com],
           encryption_algorithms: %w[
             chacha20-poly1305@openssh.com
             aes128-ctr
@@ -275,6 +259,18 @@ EOM
             aes256-ctr
             aes128-gcm@openssh.com
             aes256-gcm@openssh.com
+          ],
+          end_time: '2019-09-23 17:47:51 +0200',
+          grade: 'C',
+          hostname: 'securecodebox.io',
+          ip_address: '138.201.126.99',
+          key_algorithms: %w[
+            curve25519-sha256@libssh.org
+            ecdh-sha2-nistp256
+            ecdh-sha2-nistp384
+            ecdh-sha2-nistp521
+            diffie-hellman-group-exchange-sha256
+            diffie-hellman-group14-sha1
           ],
           mac_algorithms: %w[
             umac-64-etm@openssh.com
@@ -288,14 +284,20 @@ EOM
             hmac-sha2-512
             hmac-sha1
           ],
-          compression_algorithms: %w[none zlib@openssh.com]
+          os_cpe: 'o:canonical:ubuntu:16.04',
+          references: %w[https://wiki.mozilla.org/Security/Guidelines/OpenSSH],
+          scan_duration_seconds: 0.699356,
+          server_banner: 'SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.4',
+          ssh_lib_cpe: 'a:openssh:openssh:7.2p2',
+          ssh_version: 2.0,
+          start_time: '2019-09-23 17:47:50 +0200'
         },
         category: 'SSH Service',
-        description: 'SSH Compliance Information',
+        description: '',
         hint: '',
         id: '49bf7fd3-8512-4d73-a28f-608e493cd726',
-        location: '138.201.126.99',
-        name: 'SSH Compliance',
+        location: 'securecodebox.io',
+        name: 'SSH Service Information',
         osi_layer: 'NETWORK',
         reference: {},
         severity: 'INFORMATIONAL'
@@ -306,17 +308,19 @@ EOM
     assert_equal(
       {
         id: '49bf7fd3-8512-4d73-a28f-608e493cd726',
-        name: 'Depracated / discouraged SSH key algorithms are used',
-        description: '',
-        category: 'Insecure SSH Key Algorithms',
+        name: 'Insecure SSH Key Algorithms',
+        description: 'Deprecated / discouraged SSH key algorithms are used',
+        category: 'SSH Policy Violation',
         osi_layer: 'NETWORK',
         severity: 'MEDIUM',
         reference: {},
         hint:
           'Remove these key exchange algorithms: diffie-hellman-group14-sha1',
-        location: '138.201.126.99',
+        location: 'securecodebox.io',
         attributes: {
-          hostname: 'securecodebox.io', payload: %w[diffie-hellman-group14-sha1]
+          ip_address: '138.201.126.99',
+          hostname: 'securecodebox.io',
+          payload: %w[diffie-hellman-group14-sha1]
         }
       },
       findings[1]
@@ -325,16 +329,17 @@ EOM
     assert_equal(
       {
         id: '49bf7fd3-8512-4d73-a28f-608e493cd726',
-        name: 'Depracated / discouraged SSH MAC algorithms are used',
-        description: '',
-        category: 'Insecure SSH MAC Algorithms',
+        name: 'Insecure SSH MAC Algorithms',
+        description: 'Deprecated / discouraged SSH MAC algorithms are used',
+        category: 'SSH Policy Violation',
         osi_layer: 'NETWORK',
         severity: 'MEDIUM',
         reference: {},
         hint:
           'Remove these MAC algorithms: umac-64-etm@openssh.com, hmac-sha1-etm@openssh.com, umac-64@openssh.com, hmac-sha1',
-        location: '138.201.126.99',
+        location: 'securecodebox.io',
         attributes: {
+          ip_address: '138.201.126.99',
           hostname: 'securecodebox.io',
           payload: %w[
             umac-64-etm@openssh.com

--- a/tests/ssh_result_transformer_test.rb
+++ b/tests/ssh_result_transformer_test.rb
@@ -96,7 +96,8 @@ EOM
                  server_banner: nil,
                  ssh_lib_cpe: 'a:unknown',
                  ssh_version: 'unknown',
-                 references: nil
+                 references: nil,
+                 auth_methods: {}
              }
          }]
     )
@@ -236,60 +237,73 @@ EOM
 EOM
     result = JSON.parse(test_raw)
 
+    findings = @transformer.transform(result)
+
     assert_equal(
-        @transformer.transform(result),
-        [
-            {
-                :attributes => {
-                    :compliance_policy => "Mozilla Modern",
-                    :compliant => false,
-                    :end_time => "2019-09-23 17:47:51 +0200",
-                    :grade => "C",
-                    :hostname => "securecodebox.io",
-                    :os_cpe => "o:canonical:ubuntu:16.04",
-                    :references => ["https://wiki.mozilla.org/Security/Guidelines/OpenSSH"],
-                    :scan_duration_seconds => 0.699356,
-                    :server_banner => "SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.4",
-                    :ssh_lib_cpe => "a:openssh:openssh:7.2p2",
-                    :ssh_version => 2.0,
-                    :start_time => "2019-09-23 17:47:50 +0200"
-                },
-                :category => "SSH Service",
-                :description => "SSH Compliance Information",
-                :hint => "",
-                :id => "49bf7fd3-8512-4d73-a28f-608e493cd726",
-                :location => "138.201.126.99",
-                :name => "SSH Compliance",
-                :osi_layer => "NETWORK",
-                :reference => {},
-                :severity => "INFORMATIONAL"
+        findings.first,
+        {
+            :attributes => {
+                :compliance_policy => "Mozilla Modern",
+                :compliant => false,
+                :end_time => "2019-09-23 17:47:51 +0200",
+                :grade => "C",
+                :hostname => "securecodebox.io",
+                :os_cpe => "o:canonical:ubuntu:16.04",
+                :references => ["https://wiki.mozilla.org/Security/Guidelines/OpenSSH"],
+                :scan_duration_seconds => 0.699356,
+                :server_banner => "SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.4",
+                :ssh_lib_cpe => "a:openssh:openssh:7.2p2",
+                :ssh_version => 2.0,
+                :start_time => "2019-09-23 17:47:50 +0200",
+                :auth_methods => {
+                    "publickey" => true
+                }
             },
-            {
-                :attributes => {},
-                :category => "SSH Service",
-                :description => " diffie-hellman-group14-sha1",
-                :hint => "",
-                :id => "49bf7fd3-8512-4d73-a28f-608e493cd726",
-                :location => "138.201.126.99",
-                :name => "Remove these key exchange algorithms",
-                :osi_layer => "NETWORK",
-                :reference => {},
-                :severity => "MEDIUM"
-            },
-            {
-                :attributes => {},
-                :category => "SSH Service",
-                :description =>
-                    " umac-64-etm@openssh.com, hmac-sha1-etm@openssh.com, umac-64@openssh.com, hmac-sha1",
-                :hint => "",
-                :id => "49bf7fd3-8512-4d73-a28f-608e493cd726",
-                :location => "138.201.126.99",
-                :name => "Remove these MAC algorithms",
-                :osi_layer => "NETWORK",
-                :reference => {},
-                :severity => "MEDIUM"
-            }
-        ]
+            :category => "SSH Service",
+            :description => "SSH Compliance Information",
+            :hint => "",
+            :id => "49bf7fd3-8512-4d73-a28f-608e493cd726",
+            :location => "138.201.126.99",
+            :name => "SSH Compliance",
+            :osi_layer => "NETWORK",
+            :reference => {},
+            :severity => "INFORMATIONAL"
+        }
     )
+
+    assert_equal(
+      findings[1],
+      {
+          :attributes => {},
+          :category => "SSH Service",
+          :description => " diffie-hellman-group14-sha1",
+          :hint => "",
+          :id => "49bf7fd3-8512-4d73-a28f-608e493cd726",
+          :location => "138.201.126.99",
+          :name => "Remove these key exchange algorithms",
+          :osi_layer => "NETWORK",
+          :reference => {},
+          :severity => "MEDIUM"
+      }
+    )
+
+    assert_equal(
+      findings[2],
+        {
+            :attributes => {},
+            :category => "SSH Service",
+            :description =>
+                " umac-64-etm@openssh.com, hmac-sha1-etm@openssh.com, umac-64@openssh.com, hmac-sha1",
+            :hint => "",
+            :id => "49bf7fd3-8512-4d73-a28f-608e493cd726",
+            :location => "138.201.126.99",
+            :name => "Remove these MAC algorithms",
+            :osi_layer => "NETWORK",
+            :reference => {},
+            :severity => "MEDIUM"
+        }
+    )
+
+
   end
 end

--- a/tests/ssh_result_transformer_test.rb
+++ b/tests/ssh_result_transformer_test.rb
@@ -305,33 +305,44 @@ EOM
 
     assert_equal(
       {
-        attributes: {},
-        category: 'SSH Service',
-        description: ' diffie-hellman-group14-sha1',
-        hint: '',
         id: '49bf7fd3-8512-4d73-a28f-608e493cd726',
-        location: '138.201.126.99',
-        name: 'Remove these key exchange algorithms',
+        name: 'Depracated / discouraged SSH key algorithms are used',
+        description: '',
+        category: 'Insecure SSH Key Algorithms',
         osi_layer: 'NETWORK',
+        severity: 'MEDIUM',
         reference: {},
-        severity: 'MEDIUM'
+        hint:
+          'Remove these key exchange algorithms: diffie-hellman-group14-sha1',
+        location: '138.201.126.99',
+        attributes: {
+          hostname: 'securecodebox.io', payload: %w[diffie-hellman-group14-sha1]
+        }
       },
       findings[1]
     )
 
     assert_equal(
       {
-        attributes: {},
-        category: 'SSH Service',
-        description:
-          ' umac-64-etm@openssh.com, hmac-sha1-etm@openssh.com, umac-64@openssh.com, hmac-sha1',
-        hint: '',
         id: '49bf7fd3-8512-4d73-a28f-608e493cd726',
-        location: '138.201.126.99',
-        name: 'Remove these MAC algorithms',
+        name: 'Depracated / discouraged SSH MAC algorithms are used',
+        description: '',
+        category: 'Insecure SSH MAC Algorithms',
         osi_layer: 'NETWORK',
+        severity: 'MEDIUM',
         reference: {},
-        severity: 'MEDIUM'
+        hint:
+          'Remove these MAC algorithms: umac-64-etm@openssh.com, hmac-sha1-etm@openssh.com, umac-64@openssh.com, hmac-sha1',
+        location: '138.201.126.99',
+        attributes: {
+          hostname: 'securecodebox.io',
+          payload: %w[
+            umac-64-etm@openssh.com
+            hmac-sha1-etm@openssh.com
+            umac-64@openssh.com
+            hmac-sha1
+          ]
+        }
       },
       findings[2]
     )

--- a/tests/ssh_result_transformer_test.rb
+++ b/tests/ssh_result_transformer_test.rb
@@ -352,4 +352,73 @@ EOM
       findings[2]
     )
   end
+
+  def test_should_transform_errored_result_into_zero_findings
+    test_raw = <<EOM
+[
+  {
+    "ssh_scan_version": "0.0.42",
+    "ip": "192.168.42.42",
+    "hostname": "",
+    "port": 22,
+    "server_banner": "",
+    "ssh_version": "unknown",
+    "os": "unknown",
+    "os_cpe": "o:unknown",
+    "ssh_lib": "unknown",
+    "ssh_lib_cpe": "a:unknown",
+    "key_algorithms": [
+
+    ],
+    "encryption_algorithms_client_to_server": [
+
+    ],
+    "encryption_algorithms_server_to_client": [
+
+    ],
+    "mac_algorithms_client_to_server": [
+
+    ],
+    "mac_algorithms_server_to_client": [
+
+    ],
+    "compression_algorithms_client_to_server": [
+
+    ],
+    "compression_algorithms_server_to_client": [
+
+    ],
+    "languages_client_to_server": [
+
+    ],
+    "languages_server_to_client": [
+
+    ],
+    "auth_methods": [
+
+    ],
+    "keys": {
+    },
+    "dns_keys": null,
+    "duplicate_host_key_ips": [
+
+    ],
+    "compliance": {
+    },
+    "start_time": "2019-10-04 12:31:05 +0200",
+    "end_time": "2019-10-04 12:31:13 +0200",
+    "scan_duration_seconds": 8.005164,
+    "error": "Socket is no longer valid"
+  }
+]
+EOM
+    result = JSON.parse(test_raw)
+
+    findings = @transformer.transform(result)
+
+    assert_equal(
+      [],
+      findings
+    )
+  end
 end


### PR DESCRIPTION
## General Changes

- Change empty string fields like `hostname` and `server_banner` to null values
- The `location` of the findings will now be equal to the hostname (if existing), falling back to the `ip_address` if not set.
- All findings now have `hostname` and `ip_address` fields in their `attributes` map.
- Split out the finding categories. Currently all SSH Scanner findings are of the category `SSH Service`. This category will be kept for the general purpose informational finding. The other "policy violation" type findings will be moved into their own category. The changes to these two categories are grouped below

## Changes to `SSH Service` Category Findings

- Added extra attributes for supported `auth_methods`, `key_algorithms`, `encryption_algorithms`, `mac_algorithms` & `compression_algorithms` to easily see all relevant informations about the ssh server

## Changes to `Policy Violation` Type Findings

- These findings were previously also in the `SSH Service` Category but will now be moved into the `SSH Policy Violation` Category
- Which kind of policy was violated can be identified by the findings name. The following names are possible:
  - Insecure Methods / Algorithms:
    - `Discouraged SSH Authentication Method`
    - `Insecure SSH Key Algorithms`
    - `Insecure SSH Encryption Ciphers`
    - `Insecure SSH MAC Algorithms`
    - `Insecure SSH Compression Algorithms`
  - Missing Methods / Algorithms:
    - `Missing SSH Authentication Method`
    - `Missing SSH Key Algorithms`
    - `Missing SSH Encryption Ciphers`
    - `Missing SSH MAC Algorithms`
    - `Missing SSH Compression Algorithms`
  - `Outdated SSH Protocol Version`
- These findings have a `payload` field in their `attributes` map which indicates which kind of key algorithms, encryption ciphers or other are in violation of the policy.
- The description contains the original `ssh_scan` recommendation text.