### PR TITLE
Format ssh versions as string

### DIFF
--- a/src/ssh_result_transformer.rb
+++ b/src/ssh_result_transformer.rb
@@ -29,7 +29,7 @@ class SshResultTransformer
                     ip_address: r.dig('ip'),
                     server_banner:
                         (r.dig('server_banner') unless r.dig('server_banner').empty?),
-                    ssh_version: r.dig('ssh_version'),
+                    ssh_version: "#{r.dig('ssh_version')}",
                     os_cpe: r.dig('os_cpe'),
                     ssh_lib_cpe: r.dig('ssh_lib_cpe'),
                     compliance_policy: r.dig('compliance', 'policy'),

--- a/tests/ssh_result_transformer_test.rb
+++ b/tests/ssh_result_transformer_test.rb
@@ -289,7 +289,7 @@ EOM
           scan_duration_seconds: 0.699356,
           server_banner: 'SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.4',
           ssh_lib_cpe: 'a:openssh:openssh:7.2p2',
-          ssh_version: 2.0,
+          ssh_version: "2.0",
           start_time: '2019-09-23 17:47:50 +0200'
         },
         category: 'SSH Service',


### PR DESCRIPTION
Version Numbers should not be numbers as these are handled very differently in different environments, especially floating point number versions like `1.99`.